### PR TITLE
Merge customer-specific-applinks into develop

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -175,4 +175,4 @@ dotnet_diagnostic.IDE0051.severity = warning
 dotnet_diagnostic.CS1591.severity = none
 
 # CA1416: Validate platform compatibility
-dotnet_diagnostic.CA1416.severity = info
+dotnet_diagnostic.CA1416.severity = suggestion

--- a/AppLinks.MAUI/IAppLinkProcessor.cs
+++ b/AppLinks.MAUI/IAppLinkProcessor.cs
@@ -14,10 +14,10 @@ namespace AppLinks.MAUI
         /// This method is called by the consumer that expects
         /// app link data from a certain <paramref name="ruleId"/>.
         /// This could be a view model or just another service.
-        /// Don't forget to call <see cref="RemoveCallback(string)"/> or <see cref="RemoveCallback(AppLinkRule)"/>
+        /// Don't forget to call <see cref="RemoveCallback(object, string)"/> or <see cref="RemoveCallback(object, AppLinkRule)"/>
         /// when the consumer is no longer interested in the app link data for the given rule.
         /// </remarks>
-        void RegisterCallback(string ruleId, Action<Uri> action);
+        void RegisterCallback(object target, string ruleId, Action<Uri> action);
 
         /// <summary>
         /// Registers a callback <paramref name="action"/> for a specific rule.
@@ -26,20 +26,25 @@ namespace AppLinks.MAUI
         /// This method is called by the consumer that expects
         /// app link data from a certain <paramref name="rule"/>.
         /// This could be a view model or just another service.
-        /// Don't forget to call <see cref="RemoveCallback(string)"/> or <see cref="RemoveCallback(AppLinkRule)"/>
+        /// Don't forget to call <see cref="RemoveCallback(object, string)"/> or <see cref="RemoveCallback(object, AppLinkRule)"/>
         /// when the consumer is no longer interested in the app link data for the given rule.
         /// </remarks>
-        void RegisterCallback(AppLinkRule rule, Action<Uri> action);
+        void RegisterCallback(object target, AppLinkRule rule, Action<Uri> action);
 
         /// <summary>
         /// Removes all callbacks for a specific rule.
         /// </summary>
-        bool RemoveCallback(string ruleId);
+        bool RemoveCallback(object target, string ruleId);
 
         /// <summary>
         /// Removes all callbacks for a specific rule.
         /// </summary>
-        bool RemoveCallback(AppLinkRule rule);
+        bool RemoveCallback(object target, AppLinkRule rule);
+
+        /// <summary>
+        /// Removes all callbacks for all rules of a given <paramref name="target"/>.
+        /// </summary>
+        void ClearCallbacks(object target);
 
         /// <summary>
         /// Removes all callbacks for all rules.

--- a/AppLinks.MAUI/IAppLinkProcessor.cs
+++ b/AppLinks.MAUI/IAppLinkProcessor.cs
@@ -9,11 +9,20 @@ namespace AppLinks.MAUI
 
         /// <summary>
         /// Registers a callback <paramref name="action"/> for a specific rule.
-        /// </summary>
-        /// <remarks>
         /// This method is called by the consumer that expects
         /// app link data from a certain <paramref name="ruleId"/>.
         /// This could be a view model or just another service.
+        /// </summary>
+        /// <remarks>
+        /// Don't forget to call <see cref="RemoveCallback(string)"/> or <see cref="RemoveCallback(AppLinkRule)"/>
+        /// when the consumer is no longer interested in the app link data for the given rule.
+        /// </remarks>
+        void RegisterCallback(string ruleId, Action<Uri> action);
+
+        /// <summary>
+        /// <inheritdoc cref="RegisterCallback(string,System.Action{System.Uri})"/>
+        /// </summary>
+        /// <remarks>
         /// Don't forget to call <see cref="RemoveCallback(object, string)"/> or <see cref="RemoveCallback(object, AppLinkRule)"/>
         /// when the consumer is no longer interested in the app link data for the given rule.
         /// </remarks>
@@ -21,11 +30,20 @@ namespace AppLinks.MAUI
 
         /// <summary>
         /// Registers a callback <paramref name="action"/> for a specific rule.
-        /// </summary>
-        /// <remarks>
         /// This method is called by the consumer that expects
         /// app link data from a certain <paramref name="rule"/>.
         /// This could be a view model or just another service.
+        /// </summary>
+        /// <remarks>
+        /// Don't forget to call <see cref="RemoveCallback(object, string)"/> or <see cref="RemoveCallback(object, AppLinkRule)"/>
+        /// when the consumer is no longer interested in the app link data for the given rule.
+        /// </remarks>
+        void RegisterCallback(AppLinkRule rule, Action<Uri> action);
+
+        /// <summary>
+        /// <inheritdoc cref="RegisterCallback(AppLinkRule,System.Action{System.Uri})"/>
+        /// </summary>
+        /// <remarks>
         /// Don't forget to call <see cref="RemoveCallback(object, string)"/> or <see cref="RemoveCallback(object, AppLinkRule)"/>
         /// when the consumer is no longer interested in the app link data for the given rule.
         /// </remarks>
@@ -34,22 +52,32 @@ namespace AppLinks.MAUI
         /// <summary>
         /// Removes all callbacks for a specific rule.
         /// </summary>
+        bool RemoveCallback(string ruleId);
+
+        /// <summary>
+        /// <inheritdoc cref="RemoveCallback(string)"/>
+        /// </summary>
         bool RemoveCallback(object target, string ruleId);
 
         /// <summary>
         /// Removes all callbacks for a specific rule.
         /// </summary>
-        bool RemoveCallback(object target, AppLinkRule rule);
+        bool RemoveCallback(AppLinkRule rule);
 
         /// <summary>
-        /// Removes all callbacks for all rules of a given <paramref name="target"/>.
+        /// <inheritdoc cref="RemoveCallback(AppLinkRule)"/>
         /// </summary>
-        void ClearCallbacks(object target);
+        bool RemoveCallback(object target, AppLinkRule rule);
 
         /// <summary>
         /// Removes all callbacks for all rules.
         /// </summary>
         void ClearCallbacks();
+
+        /// <summary>
+        /// Removes all callbacks for all rules of a given <paramref name="target"/>.
+        /// </summary>
+        void ClearCallbacks(object target);
 
         /// <summary>
         /// Processes the given <paramref name="uri"/> with all registered rules.

--- a/Samples/AppLinksDemoApp/ViewModels/MainViewModel.cs
+++ b/Samples/AppLinksDemoApp/ViewModels/MainViewModel.cs
@@ -80,7 +80,7 @@ namespace AppLinksDemoApp.ViewModels
 
                 // Register for app link calls backs.
                 // We use the static app link rules here.
-                // IAppLinkProcessor.Current.RegisterCallback(StaticAppLinkRules.HomeRule,
+                // IAppLinkProcessor.Current.RegisterCallback(this, StaticAppLinkRules.HomeRule,
                 //     uri => this.dialogService.DisplayAlertAsync(
                 //         StaticAppLinkRules.HomeRule.RuleId,
                 //         $"Callback for rule \"{StaticAppLinkRules.HomeRule.RuleId}\"{Environment.NewLine}{Environment.NewLine}" +
@@ -89,18 +89,22 @@ namespace AppLinksDemoApp.ViewModels
 
                 // Register for app link calls backs.
                 // We use injected app link rules here.
-                this.appLinkProcessor.RegisterCallback(this.appLinkRules.HomeRule,
-                    uri => this.dialogService.DisplayAlertAsync(
-                        this.appLinkRules.HomeRule.RuleId,
-                        $"Callback for rule \"{this.appLinkRules.HomeRule.RuleId}\"{Environment.NewLine}{Environment.NewLine}" +
-                        $"URI {uri}",
-                        "OK"));
+                this.appLinkProcessor.RegisterCallback(this, this.appLinkRules.HomeRule, async uri => await this.HandleHomeRuleAppLinkAsync(uri));
             }
             catch (Exception ex)
             {
                 this.logger.LogError(ex, "InitializeAsync failed with exception");
                 await this.dialogService.DisplayAlertAsync("Error", "Initialization failed", "OK");
             }
+        }
+
+        private async Task HandleHomeRuleAppLinkAsync(Uri uri)
+        {
+            await this.dialogService.DisplayAlertAsync(
+                this.appLinkRules.HomeRule.RuleId,
+                $"Callback for rule \"{this.appLinkRules.HomeRule.RuleId}\"{Environment.NewLine}{Environment.NewLine}" +
+                $"URI {uri}",
+                "OK");
         }
 
         public ICommand SubscribeToAppLinkReceivedEventCommand

--- a/Tests/AppLinks.MAUI.Tests/AppLinkProcessorTests.cs
+++ b/Tests/AppLinks.MAUI.Tests/AppLinkProcessorTests.cs
@@ -214,6 +214,42 @@ namespace AppLinks.MAUI.Tests
         }
 
         [Fact]
+        public void ClearCallbacks_WithTarget_ShouldNoLongerCallAction()
+        {
+            // Arrange
+            var uris = new List<(string, Uri)>();
+            var processor = this.autoMocker.CreateInstance<AppLinkProcessor>(enablePrivate: true);
+            var appLinkRule = new AppLinkRule("HomePageRule", uri => uri.Host == "example.com" && uri.AbsolutePath == "/home");
+            processor.Add(appLinkRule);
+            processor.RegisterCallback(this, appLinkRule, u => uris.Add(("HomePageRule", u)));
+
+            // Act
+            processor.ClearCallbacks();
+            processor.Process(new Uri("https://example.com/home"));
+
+            // Assert
+            uris.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ClearCallbacks_WithoutTarget_ShouldNoLongerCallAction()
+        {
+            // Arrange
+            var uris = new List<(string, Uri)>();
+            var processor = this.autoMocker.CreateInstance<AppLinkProcessor>(enablePrivate: true);
+            var appLinkRule = new AppLinkRule("HomePageRule", uri => uri.Host == "example.com" && uri.AbsolutePath == "/home");
+            processor.Add(appLinkRule);
+            processor.RegisterCallback(this, appLinkRule, u => uris.Add(("HomePageRule", u)));
+
+            // Act
+            processor.ClearCallbacks(this);
+            processor.Process(new Uri("https://example.com/home"));
+
+            // Assert
+            uris.Should().BeEmpty();
+        }
+
+        [Fact]
         public void ClearCache_ShouldRemoveAllPendingUris()
         {
             // Arrange

--- a/Tests/AppLinks.MAUI.Tests/AppLinkProcessorTests.cs
+++ b/Tests/AppLinks.MAUI.Tests/AppLinkProcessorTests.cs
@@ -34,9 +34,9 @@ namespace AppLinks.MAUI.Tests
             processor.Add(new AppLinkRule("SettingsPageRule", uri => uri.Host == "example.com" && uri.AbsolutePath == "/settings"));
             processor.Add(new AppLinkRule("QueryActionRule", uri => uri.Host == "example.com" && uri.Query.Contains("action=view")));
 
-            processor.RegisterCallback(this, "HomePageRule", u => uris.Add(("HomePageRule", u)));
-            processor.RegisterCallback(this, "SettingsPageRule", u => uris.Add(("SettingsPageRule", u)));
-            processor.RegisterCallback(this, "QueryActionRule", u => uris.Add(("QueryActionRule", u)));
+            processor.RegisterCallback("HomePageRule", u => uris.Add(("HomePageRule", u)));
+            processor.RegisterCallback("SettingsPageRule", u => uris.Add(("SettingsPageRule", u)));
+            processor.RegisterCallback("QueryActionRule", u => uris.Add(("QueryActionRule", u)));
 
             // Act
             processor.Process(new Uri("https://example.com/home"));

--- a/Tests/AppLinks.MAUI.Tests/AppLinkProcessorTests.cs
+++ b/Tests/AppLinks.MAUI.Tests/AppLinkProcessorTests.cs
@@ -34,9 +34,9 @@ namespace AppLinks.MAUI.Tests
             processor.Add(new AppLinkRule("SettingsPageRule", uri => uri.Host == "example.com" && uri.AbsolutePath == "/settings"));
             processor.Add(new AppLinkRule("QueryActionRule", uri => uri.Host == "example.com" && uri.Query.Contains("action=view")));
 
-            processor.RegisterCallback("HomePageRule", u => uris.Add(("HomePageRule", u)));
-            processor.RegisterCallback("SettingsPageRule", u => uris.Add(("SettingsPageRule", u)));
-            processor.RegisterCallback("QueryActionRule", u => uris.Add(("QueryActionRule", u)));
+            processor.RegisterCallback(this, "HomePageRule", u => uris.Add(("HomePageRule", u)));
+            processor.RegisterCallback(this, "SettingsPageRule", u => uris.Add(("SettingsPageRule", u)));
+            processor.RegisterCallback(this, "QueryActionRule", u => uris.Add(("QueryActionRule", u)));
 
             // Act
             processor.Process(new Uri("https://example.com/home"));
@@ -59,13 +59,13 @@ namespace AppLinks.MAUI.Tests
             processor.Add(new AppLinkRule("HomePageRule", uri => uri.Host == "example.com" && uri.AbsolutePath == "/home"));
             processor.Add(new AppLinkRule("SettingsPageRule", uri => uri.Host == "example.com" && uri.AbsolutePath == "/settings"));
 
-            processor.RegisterCallback("HomePageRule", u => uris.Add(("HomePageRule", u)));
+            processor.RegisterCallback(this, "HomePageRule", u => uris.Add(("HomePageRule", u)));
 
             processor.Process(new Uri("https://example.com/home"));
             processor.Process(new Uri("https://example.com/settings"));
 
             // Act
-            processor.RegisterCallback("SettingsPageRule", u => uris.Add(("SettingsPageRule", u)));
+            processor.RegisterCallback(this, "SettingsPageRule", u => uris.Add(("SettingsPageRule", u)));
 
             // Assert
             uris.Should().HaveCount(2);
@@ -86,7 +86,7 @@ namespace AppLinks.MAUI.Tests
             processor.Process(new Uri("https://example.com/home"));
 
             // Act
-            processor.RegisterCallback("HomePageRule", u => uris.Add(("HomePageRule", u)));
+            processor.RegisterCallback(this, "HomePageRule", u => uris.Add(("HomePageRule", u)));
 
             // Assert
             uris.Should().HaveCount(1);
@@ -102,7 +102,7 @@ namespace AppLinks.MAUI.Tests
             var processor = this.autoMocker.CreateInstance<AppLinkProcessor>(enablePrivate: true);
 
             // Act
-            processor.RegisterCallback("HomePageRule", _ => {});
+            processor.RegisterCallback(this, "HomePageRule", _ => {});
 
             // Assert
             loggerMock.Verify(
@@ -113,8 +113,6 @@ namespace AppLinks.MAUI.Tests
                     It.IsAny<Exception>(),
                     It.IsAny<Func<It.IsAnyType, Exception, string>>()),
                 Times.Once);
-
-            loggerMock.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -123,7 +121,7 @@ namespace AppLinks.MAUI.Tests
             // Arrange
             var appRuleCalls = new List<string>();
             var processor = this.autoMocker.CreateInstance<AppLinkProcessor>(enablePrivate: true);
-            processor.RegisterCallback("HomePageRule", uri => {});
+            processor.RegisterCallback(this, "HomePageRule", uri => {});
 
             var appLinkRuleHome1 = new AppLinkRule("HomePageRule", uri => { appRuleCalls.Add("appLinkRuleHome1"); return true; });
             var appLinkRuleHome2 = new AppLinkRule("HomePageRule", uri => { appRuleCalls.Add("appLinkRuleHome2"); return true; });
@@ -149,10 +147,10 @@ namespace AppLinks.MAUI.Tests
             var uris = new List<(string, Uri)>();
             var processor = this.autoMocker.CreateInstance<AppLinkProcessor>(enablePrivate: true);
             processor.Add(new AppLinkRule("HomePageRule", uri => uri.Host == "example.com" && uri.AbsolutePath == "/home"));
-            processor.RegisterCallback("HomePageRule", u => uris.Add(("HomePageRule", u)));
+            processor.RegisterCallback(this, "HomePageRule", u => uris.Add(("HomePageRule", u)));
 
             // Act
-            var removed = processor.RemoveCallback("HomePageRule");
+            var removed = processor.RemoveCallback(this, "HomePageRule");
             processor.Process(new Uri("https://example.com/home"));
 
             // Assert
@@ -168,10 +166,10 @@ namespace AppLinks.MAUI.Tests
             var processor = this.autoMocker.CreateInstance<AppLinkProcessor>(enablePrivate: true);
             var appLinkRule = new AppLinkRule("HomePageRule", uri => uri.Host == "example.com" && uri.AbsolutePath == "/home");
             processor.Add(appLinkRule);
-            processor.RegisterCallback(appLinkRule, u => uris.Add(("HomePageRule", u)));
+            processor.RegisterCallback(this, appLinkRule, u => uris.Add(("HomePageRule", u)));
 
             // Act
-            var removed = processor.RemoveCallback(appLinkRule);
+            var removed = processor.RemoveCallback(this, appLinkRule);
             processor.Process(new Uri("https://example.com/home"));
 
             // Assert
@@ -187,7 +185,7 @@ namespace AppLinks.MAUI.Tests
             var processor = this.autoMocker.CreateInstance<AppLinkProcessor>(enablePrivate: true);
             var appLinkRule = new AppLinkRule("HomePageRule", uri => uri.Host == "example.com" && uri.AbsolutePath == "/home");
             processor.Add(appLinkRule);
-            processor.RegisterCallback(appLinkRule, u => uris.Add(("HomePageRule", u)));
+            processor.RegisterCallback(this, appLinkRule, u => uris.Add(("HomePageRule", u)));
 
             // Act
             processor.Remove(appLinkRule);
@@ -205,7 +203,7 @@ namespace AppLinks.MAUI.Tests
             var processor = this.autoMocker.CreateInstance<AppLinkProcessor>(enablePrivate: true);
             var appLinkRule = new AppLinkRule("HomePageRule", uri => uri.Host == "example.com" && uri.AbsolutePath == "/home");
             processor.Add(appLinkRule);
-            processor.RegisterCallback(appLinkRule, u => uris.Add(("HomePageRule", u)));
+            processor.RegisterCallback(this, appLinkRule, u => uris.Add(("HomePageRule", u)));
 
             // Act
             processor.Remove("HomePageRule");
@@ -227,7 +225,7 @@ namespace AppLinks.MAUI.Tests
 
             // Act
             processor.ClearCache();
-            processor.RegisterCallback("HomePageRule", u => uris.Add(("HomePageRule", u)));
+            processor.RegisterCallback(this, "HomePageRule", u => uris.Add(("HomePageRule", u)));
 
             // Assert
             uris.Should().BeEmpty();


### PR DESCRIPTION
Register app link callbacks with a target name so that we can have multiple targets registering for the same app link callback.